### PR TITLE
[T2] GitHub API クライアント実装

### DIFF
--- a/src/lib/github/client.test.ts
+++ b/src/lib/github/client.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GitHubApiError,
+  getIssues,
+  getPullRequests,
+  getRepository,
+  validateToken,
+} from "./client";
+import type {
+  GitHubIssue,
+  GitHubPullRequest,
+  GitHubRepository,
+  GitHubUser,
+} from "./types";
+
+// --- helpers ---
+
+function mockResponse(
+  data: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    json: () => Promise.resolve(data),
+    headers: { get: (key: string) => headers[key.toLowerCase()] ?? null },
+  });
+}
+
+// --- fixtures ---
+
+const mockUser: GitHubUser = {
+  login: "testuser",
+  id: 1,
+  avatar_url: "https://avatars.githubusercontent.com/u/1",
+  html_url: "https://github.com/testuser",
+};
+
+const mockRepo: GitHubRepository = {
+  id: 123,
+  name: "test-repo",
+  full_name: "testuser/test-repo",
+  private: false,
+  html_url: "https://github.com/testuser/test-repo",
+  description: "A test repository",
+};
+
+const mockIssue: GitHubIssue = {
+  id: 1,
+  number: 1,
+  title: "Test Issue",
+  state: "open",
+  body: "Issue body",
+  html_url: "https://github.com/testuser/test-repo/issues/1",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-02T00:00:00Z",
+  closed_at: null,
+  labels: [],
+  assignees: [],
+  milestone: null,
+  user: mockUser,
+};
+
+const mockPR: GitHubPullRequest = {
+  id: 2,
+  number: 2,
+  title: "Test PR",
+  state: "open",
+  draft: false,
+  body: "PR body",
+  html_url: "https://github.com/testuser/test-repo/pull/2",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-02T00:00:00Z",
+  closed_at: null,
+  merged_at: null,
+  labels: [],
+  assignees: [],
+  milestone: null,
+  user: mockUser,
+};
+
+// --- tests ---
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("validateToken", () => {
+  it("有効なトークンでユーザー情報を返す", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(mockResponse(mockUser) as never);
+    const result = await validateToken("valid-token");
+    expect(result).toEqual(mockUser);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer valid-token",
+        }),
+      }),
+    );
+  });
+
+  it("401 で GitHubApiError(status=401) を throw する", async () => {
+    vi.mocked(fetch).mockReturnValue(
+      mockResponse({ message: "Bad credentials" }, 401) as never,
+    );
+    const error = await validateToken("bad-token").catch((e) => e);
+    expect(error).toBeInstanceOf(GitHubApiError);
+    expect(error.status).toBe(401);
+    expect(error.message).toBe("Bad credentials");
+  });
+
+  it("403 で GitHubApiError(status=403) を throw する", async () => {
+    vi.mocked(fetch).mockReturnValue(
+      mockResponse({ message: "Forbidden" }, 403) as never,
+    );
+    const error = await validateToken("token").catch((e) => e);
+    expect(error).toBeInstanceOf(GitHubApiError);
+    expect(error.status).toBe(403);
+  });
+
+  it("レスポンスボディが JSON でない場合は statusText をメッセージにする", async () => {
+    vi.mocked(fetch).mockReturnValue(
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        json: () => Promise.reject(new Error("not json")),
+        headers: { get: () => null },
+      }) as never,
+    );
+    const error = await validateToken("token").catch((e) => e);
+    expect(error).toBeInstanceOf(GitHubApiError);
+    expect(error.status).toBe(500);
+    expect(error.message).toBe("Internal Server Error");
+  });
+});
+
+describe("getRepository", () => {
+  it("リポジトリ情報を返す", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(mockResponse(mockRepo) as never);
+    const result = await getRepository("testuser", "test-repo", "token");
+    expect(result).toEqual(mockRepo);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/testuser/test-repo",
+      expect.anything(),
+    );
+  });
+
+  it("404 で GitHubApiError(status=404) を throw する", async () => {
+    vi.mocked(fetch).mockReturnValue(
+      mockResponse({ message: "Not Found" }, 404) as never,
+    );
+    const error = await getRepository("x", "y", "token").catch((e) => e);
+    expect(error).toBeInstanceOf(GitHubApiError);
+    expect(error.status).toBe(404);
+  });
+});
+
+describe("getIssues", () => {
+  it("Issue 一覧を返す", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(mockResponse([mockIssue]) as never);
+    const result = await getIssues("testuser", "test-repo", "token");
+    expect(result).toEqual([mockIssue]);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/testuser/test-repo/issues?state=all&per_page=100",
+      expect.anything(),
+    );
+  });
+
+  it("複数ページのデータを全件取得する", async () => {
+    const page1 = [{ ...mockIssue, id: 1, number: 1 }];
+    const page2 = [{ ...mockIssue, id: 2, number: 2 }];
+    vi.mocked(fetch)
+      .mockReturnValueOnce(
+        mockResponse(page1, 200, {
+          link: '<https://api.github.com/repos/testuser/test-repo/issues?state=all&per_page=100&page=2>; rel="next"',
+        }) as never,
+      )
+      .mockReturnValueOnce(mockResponse(page2) as never);
+
+    const result = await getIssues("testuser", "test-repo", "token");
+    expect(result).toHaveLength(2);
+    expect(result[0].number).toBe(1);
+    expect(result[1].number).toBe(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("429 で GitHubApiError(status=429) を throw する", async () => {
+    vi.mocked(fetch).mockReturnValue(
+      mockResponse({ message: "rate limit exceeded" }, 429) as never,
+    );
+    const error = await getIssues("testuser", "test-repo", "token").catch(
+      (e) => e,
+    );
+    expect(error).toBeInstanceOf(GitHubApiError);
+    expect(error.status).toBe(429);
+  });
+});
+
+describe("getPullRequests", () => {
+  it("PR 一覧を返す", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(mockResponse([mockPR]) as never);
+    const result = await getPullRequests("testuser", "test-repo", "token");
+    expect(result).toEqual([mockPR]);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/testuser/test-repo/pulls?state=all&per_page=100",
+      expect.anything(),
+    );
+  });
+
+  it("複数ページのデータを全件取得する", async () => {
+    const page1 = [{ ...mockPR, id: 1, number: 1 }];
+    const page2 = [{ ...mockPR, id: 2, number: 2 }];
+    vi.mocked(fetch)
+      .mockReturnValueOnce(
+        mockResponse(page1, 200, {
+          link: '<https://api.github.com/repos/testuser/test-repo/pulls?state=all&per_page=100&page=2>; rel="next"',
+        }) as never,
+      )
+      .mockReturnValueOnce(mockResponse(page2) as never);
+
+    const result = await getPullRequests("testuser", "test-repo", "token");
+    expect(result).toHaveLength(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("401 で GitHubApiError(status=401) を throw する", async () => {
+    vi.mocked(fetch).mockReturnValue(
+      mockResponse({ message: "Bad credentials" }, 401) as never,
+    );
+    const error = await getPullRequests("testuser", "test-repo", "token").catch(
+      (e) => e,
+    );
+    expect(error).toBeInstanceOf(GitHubApiError);
+    expect(error.status).toBe(401);
+  });
+});

--- a/src/lib/github/client.ts
+++ b/src/lib/github/client.ts
@@ -1,0 +1,102 @@
+import type {
+  GitHubIssue,
+  GitHubPullRequest,
+  GitHubRepository,
+  GitHubUser,
+} from "./types";
+
+const BASE_URL = "https://api.github.com";
+
+export class GitHubApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GitHubApiError";
+  }
+}
+
+function buildHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function githubFetch(url: string, token: string): Promise<Response> {
+  const response = await fetch(url, { headers: buildHeaders(token) });
+
+  if (!response.ok) {
+    let message = response.statusText;
+    try {
+      const data = (await response.json()) as { message?: string };
+      if (typeof data.message === "string") message = data.message;
+    } catch {
+      // use statusText as fallback
+    }
+    throw new GitHubApiError(response.status, message);
+  }
+
+  return response;
+}
+
+function parseNextUrl(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+  return match ? match[1] : null;
+}
+
+async function fetchAllPages<T>(url: string, token: string): Promise<T[]> {
+  const results: T[] = [];
+  let nextUrl: string | null = `${url}&per_page=100`;
+
+  while (nextUrl) {
+    const response = await githubFetch(nextUrl, token);
+    const data = (await response.json()) as T[];
+    results.push(...data);
+    nextUrl = parseNextUrl(response.headers.get("Link"));
+  }
+
+  return results;
+}
+
+export async function validateToken(token: string): Promise<GitHubUser> {
+  const response = await githubFetch(`${BASE_URL}/user`, token);
+  return response.json() as Promise<GitHubUser>;
+}
+
+export async function getRepository(
+  owner: string,
+  repo: string,
+  token: string,
+): Promise<GitHubRepository> {
+  const response = await githubFetch(
+    `${BASE_URL}/repos/${owner}/${repo}`,
+    token,
+  );
+  return response.json() as Promise<GitHubRepository>;
+}
+
+export async function getIssues(
+  owner: string,
+  repo: string,
+  token: string,
+): Promise<GitHubIssue[]> {
+  return fetchAllPages<GitHubIssue>(
+    `${BASE_URL}/repos/${owner}/${repo}/issues?state=all`,
+    token,
+  );
+}
+
+export async function getPullRequests(
+  owner: string,
+  repo: string,
+  token: string,
+): Promise<GitHubPullRequest[]> {
+  return fetchAllPages<GitHubPullRequest>(
+    `${BASE_URL}/repos/${owner}/${repo}/pulls?state=all`,
+    token,
+  );
+}

--- a/src/lib/github/client.ts
+++ b/src/lib/github/client.ts
@@ -50,7 +50,9 @@ function parseNextUrl(linkHeader: string | null): string | null {
 
 async function fetchAllPages<T>(url: string, token: string): Promise<T[]> {
   const results: T[] = [];
-  let nextUrl: string | null = `${url}&per_page=100`;
+  const initialUrl = new URL(url);
+  initialUrl.searchParams.set("per_page", "100");
+  let nextUrl: string | null = initialUrl.toString();
 
   while (nextUrl) {
     const response = await githubFetch(nextUrl, token);

--- a/src/lib/github/types.ts
+++ b/src/lib/github/types.ts
@@ -45,7 +45,7 @@ export type GitHubIssue = {
   pull_request?: {
     url: string;
     html_url: string;
-    merged_at: string | null;
+    merged_at?: string | null;
   };
 };
 

--- a/src/lib/github/types.ts
+++ b/src/lib/github/types.ts
@@ -1,0 +1,68 @@
+export type GitHubUser = {
+  login: string;
+  id: number;
+  avatar_url: string;
+  html_url: string;
+};
+
+export type GitHubLabel = {
+  id: number;
+  name: string;
+  color: string;
+  description: string | null;
+};
+
+export type GitHubMilestone = {
+  id: number;
+  number: number;
+  title: string;
+  state: "open" | "closed";
+};
+
+export type GitHubRepository = {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  html_url: string;
+  description: string | null;
+};
+
+export type GitHubIssue = {
+  id: number;
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  body: string | null;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  labels: GitHubLabel[];
+  assignees: GitHubUser[];
+  milestone: GitHubMilestone | null;
+  user: GitHubUser;
+  pull_request?: {
+    url: string;
+    html_url: string;
+    merged_at: string | null;
+  };
+};
+
+export type GitHubPullRequest = {
+  id: number;
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  draft: boolean;
+  body: string | null;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  merged_at: string | null;
+  labels: GitHubLabel[];
+  assignees: GitHubUser[];
+  milestone: GitHubMilestone | null;
+  user: GitHubUser;
+};


### PR DESCRIPTION
## 概要

GitHub REST API v3 を呼び出すクライアントを実装。

## 変更内容

- **`src/lib/github/types.ts`**: GitHub API レスポンスの型定義
  - `GitHubUser`, `GitHubLabel`, `GitHubMilestone`, `GitHubRepository`, `GitHubIssue`, `GitHubPullRequest`
- **`src/lib/github/client.ts`**: API クライアント実装
  - 認証ヘッダー付き fetch ラッパー
  - `Link` ヘッダーによるページネーション対応（全件取得）
  - `validateToken` / `getRepository` / `getIssues` / `getPullRequests`
  - エラーハンドリング（`GitHubApiError` クラス、401/403/404/429 等）
- **`src/lib/github/client.test.ts`**: ユニットテスト 12件
  - 正常系レスポンス
  - エラーケース（401/403/404/429）
  - 複数ページの全件取得（ページネーション）

## テスト結果

```
✓ src/lib/github/client.test.ts (12 tests)
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Closes #2