### PR TITLE
[T3] localStorage ユーティリティ実装

### DIFF
--- a/src/lib/storage/cache.test.ts
+++ b/src/lib/storage/cache.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_TTL,
+  clearAllCache,
+  clearCache,
+  getCache,
+  setCache,
+} from "./cache";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("setCache / getCache", () => {
+  it("データを保存・取得できる", () => {
+    setCache("owner/repo", { items: [1, 2, 3] });
+    expect(getCache("owner/repo")).toEqual({ items: [1, 2, 3] });
+  });
+
+  it("存在しないキーは null を返す", () => {
+    expect(getCache("owner/repo")).toBeNull();
+  });
+
+  it("TTL 期限切れのキャッシュは null を返す", () => {
+    const expired = {
+      data: { items: [] },
+      timestamp: Date.now() - DEFAULT_TTL - 1,
+    };
+    localStorage.setItem("giv:cache:owner/repo", JSON.stringify(expired));
+    expect(getCache("owner/repo")).toBeNull();
+  });
+
+  it("TTL 内のキャッシュはデータを返す", () => {
+    const fresh = {
+      data: { items: [1] },
+      timestamp: Date.now() - DEFAULT_TTL + 10_000,
+    };
+    localStorage.setItem("giv:cache:owner/repo", JSON.stringify(fresh));
+    expect(getCache("owner/repo")).toEqual({ items: [1] });
+  });
+
+  it("カスタム TTL を指定できる", () => {
+    const entry = { data: "test", timestamp: Date.now() - 1_000 };
+    localStorage.setItem("giv:cache:key", JSON.stringify(entry));
+    expect(getCache("key", 500)).toBeNull(); // 500ms → 期限切れ
+    expect(getCache("key", 2_000)).toBe("test"); // 2000ms → 有効
+  });
+
+  it("壊れた JSON は null を返す", () => {
+    localStorage.setItem("giv:cache:owner/repo", "invalid-json");
+    expect(getCache("owner/repo")).toBeNull();
+  });
+});
+
+describe("clearCache", () => {
+  it("指定したキーのキャッシュを削除できる", () => {
+    setCache("owner/repo", { items: [] });
+    clearCache("owner/repo");
+    expect(getCache("owner/repo")).toBeNull();
+  });
+
+  it("他のキャッシュには影響しない", () => {
+    setCache("owner/repo1", { items: [1] });
+    setCache("owner/repo2", { items: [2] });
+    clearCache("owner/repo1");
+    expect(getCache("owner/repo2")).toEqual({ items: [2] });
+  });
+});
+
+describe("clearAllCache", () => {
+  it("すべてのキャッシュを削除できる", () => {
+    setCache("owner/repo1", { items: [] });
+    setCache("owner/repo2", { items: [] });
+    clearAllCache();
+    expect(getCache("owner/repo1")).toBeNull();
+    expect(getCache("owner/repo2")).toBeNull();
+  });
+
+  it("キャッシュ以外の localStorage エントリは削除しない", () => {
+    setCache("owner/repo", { items: [] });
+    localStorage.setItem("giv:token", "my-token");
+    clearAllCache();
+    expect(getCache("owner/repo")).toBeNull();
+    expect(localStorage.getItem("giv:token")).toBe("my-token");
+  });
+});

--- a/src/lib/storage/cache.ts
+++ b/src/lib/storage/cache.ts
@@ -8,9 +8,9 @@ type CacheEntry<T> = {
 
 export function getCache<T>(key: string, ttl = DEFAULT_TTL): T | null {
   const cacheKey = `${CACHE_PREFIX}${key}`;
-  const raw = localStorage.getItem(cacheKey);
-  if (!raw) return null;
   try {
+    const raw = localStorage.getItem(cacheKey);
+    if (!raw) return null;
     const entry = JSON.parse(raw) as unknown;
     if (
       typeof entry !== "object" ||
@@ -29,21 +29,33 @@ export function getCache<T>(key: string, ttl = DEFAULT_TTL): T | null {
 }
 
 export function setCache<T>(key: string, data: T): void {
-  const entry: CacheEntry<T> = { data, timestamp: Date.now() };
-  localStorage.setItem(`${CACHE_PREFIX}${key}`, JSON.stringify(entry));
+  try {
+    const entry: CacheEntry<T> = { data, timestamp: Date.now() };
+    localStorage.setItem(`${CACHE_PREFIX}${key}`, JSON.stringify(entry));
+  } catch {
+    // ストレージ制限環境では無視
+  }
 }
 
 export function clearCache(key: string): void {
-  localStorage.removeItem(`${CACHE_PREFIX}${key}`);
+  try {
+    localStorage.removeItem(`${CACHE_PREFIX}${key}`);
+  } catch {
+    // ストレージ制限環境では無視
+  }
 }
 
 export function clearAllCache(): void {
-  const keysToRemove: string[] = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const k = localStorage.key(i);
-    if (k?.startsWith(CACHE_PREFIX)) keysToRemove.push(k);
-  }
-  for (const k of keysToRemove) {
-    localStorage.removeItem(k);
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k?.startsWith(CACHE_PREFIX)) keysToRemove.push(k);
+    }
+    for (const k of keysToRemove) {
+      localStorage.removeItem(k);
+    }
+  } catch {
+    // ストレージ制限環境では無視
   }
 }

--- a/src/lib/storage/cache.ts
+++ b/src/lib/storage/cache.ts
@@ -7,12 +7,22 @@ type CacheEntry<T> = {
 };
 
 export function getCache<T>(key: string, ttl = DEFAULT_TTL): T | null {
-  const raw = localStorage.getItem(`${CACHE_PREFIX}${key}`);
+  const cacheKey = `${CACHE_PREFIX}${key}`;
+  const raw = localStorage.getItem(cacheKey);
   if (!raw) return null;
   try {
-    const entry = JSON.parse(raw) as CacheEntry<T>;
-    if (Date.now() - entry.timestamp > ttl) return null;
-    return entry.data;
+    const entry = JSON.parse(raw) as unknown;
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as { timestamp?: unknown }).timestamp !== "number"
+    ) {
+      localStorage.removeItem(cacheKey);
+      return null;
+    }
+    const cacheEntry = entry as CacheEntry<T>;
+    if (Date.now() - cacheEntry.timestamp > ttl) return null;
+    return cacheEntry.data;
   } catch {
     return null;
   }

--- a/src/lib/storage/cache.ts
+++ b/src/lib/storage/cache.ts
@@ -1,0 +1,39 @@
+const CACHE_PREFIX = "giv:cache:";
+export const DEFAULT_TTL = 300_000; // 5分
+
+type CacheEntry<T> = {
+  data: T;
+  timestamp: number;
+};
+
+export function getCache<T>(key: string, ttl = DEFAULT_TTL): T | null {
+  const raw = localStorage.getItem(`${CACHE_PREFIX}${key}`);
+  if (!raw) return null;
+  try {
+    const entry = JSON.parse(raw) as CacheEntry<T>;
+    if (Date.now() - entry.timestamp > ttl) return null;
+    return entry.data;
+  } catch {
+    return null;
+  }
+}
+
+export function setCache<T>(key: string, data: T): void {
+  const entry: CacheEntry<T> = { data, timestamp: Date.now() };
+  localStorage.setItem(`${CACHE_PREFIX}${key}`, JSON.stringify(entry));
+}
+
+export function clearCache(key: string): void {
+  localStorage.removeItem(`${CACHE_PREFIX}${key}`);
+}
+
+export function clearAllCache(): void {
+  const keysToRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (k?.startsWith(CACHE_PREFIX)) keysToRemove.push(k);
+  }
+  for (const k of keysToRemove) {
+    localStorage.removeItem(k);
+  }
+}

--- a/src/lib/storage/settings.test.ts
+++ b/src/lib/storage/settings.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  addRepo,
+  getRepos,
+  getToken,
+  removeRepo,
+  removeToken,
+  setToken,
+} from "./settings";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("getToken / setToken / removeToken", () => {
+  it("未設定の場合は null を返す", () => {
+    expect(getToken()).toBeNull();
+  });
+
+  it("トークンを保存・取得できる", () => {
+    setToken("my-token");
+    expect(getToken()).toBe("my-token");
+  });
+
+  it("トークンを上書きできる", () => {
+    setToken("old-token");
+    setToken("new-token");
+    expect(getToken()).toBe("new-token");
+  });
+
+  it("トークンを削除できる", () => {
+    setToken("my-token");
+    removeToken();
+    expect(getToken()).toBeNull();
+  });
+});
+
+describe("getRepos / addRepo / removeRepo", () => {
+  it("未設定の場合は空配列を返す", () => {
+    expect(getRepos()).toEqual([]);
+  });
+
+  it("リポジトリを追加・取得できる", () => {
+    addRepo("owner/repo");
+    expect(getRepos()).toEqual(["owner/repo"]);
+  });
+
+  it("同じリポジトリを重複追加しない", () => {
+    addRepo("owner/repo");
+    addRepo("owner/repo");
+    expect(getRepos()).toHaveLength(1);
+  });
+
+  it("複数のリポジトリを追加できる", () => {
+    addRepo("owner/repo1");
+    addRepo("owner/repo2");
+    expect(getRepos()).toEqual(["owner/repo1", "owner/repo2"]);
+  });
+
+  it("リポジトリを削除できる", () => {
+    addRepo("owner/repo1");
+    addRepo("owner/repo2");
+    removeRepo("owner/repo1");
+    expect(getRepos()).toEqual(["owner/repo2"]);
+  });
+
+  it("存在しないリポジトリの削除は何もしない", () => {
+    addRepo("owner/repo");
+    removeRepo("owner/other");
+    expect(getRepos()).toEqual(["owner/repo"]);
+  });
+
+  it("localStorage が壊れている場合は空配列を返す", () => {
+    localStorage.setItem("giv:repos", "invalid-json");
+    expect(getRepos()).toEqual([]);
+  });
+});

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -1,0 +1,38 @@
+const TOKEN_KEY = "giv:token";
+const REPOS_KEY = "giv:repos";
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function removeToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export function getRepos(): string[] {
+  const raw = localStorage.getItem(REPOS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addRepo(repo: string): void {
+  const repos = getRepos();
+  if (!repos.includes(repo)) {
+    repos.push(repo);
+    localStorage.setItem(REPOS_KEY, JSON.stringify(repos));
+  }
+}
+
+export function removeRepo(repo: string): void {
+  const repos = getRepos().filter((r) => r !== repo);
+  localStorage.setItem(REPOS_KEY, JSON.stringify(repos));
+}

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -2,21 +2,33 @@ const TOKEN_KEY = "giv:token";
 const REPOS_KEY = "giv:repos";
 
 export function getToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
+  try {
+    return localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
 }
 
 export function setToken(token: string): void {
-  localStorage.setItem(TOKEN_KEY, token);
+  try {
+    localStorage.setItem(TOKEN_KEY, token);
+  } catch {
+    // ストレージ制限環境では無視
+  }
 }
 
 export function removeToken(): void {
-  localStorage.removeItem(TOKEN_KEY);
+  try {
+    localStorage.removeItem(TOKEN_KEY);
+  } catch {
+    // ストレージ制限環境では無視
+  }
 }
 
 export function getRepos(): string[] {
-  const raw = localStorage.getItem(REPOS_KEY);
-  if (!raw) return [];
   try {
+    const raw = localStorage.getItem(REPOS_KEY);
+    if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
     return Array.isArray(parsed) &&
       parsed.every((item) => typeof item === "string")
@@ -28,14 +40,22 @@ export function getRepos(): string[] {
 }
 
 export function addRepo(repo: string): void {
-  const repos = getRepos();
-  if (!repos.includes(repo)) {
-    repos.push(repo);
-    localStorage.setItem(REPOS_KEY, JSON.stringify(repos));
+  try {
+    const repos = getRepos();
+    if (!repos.includes(repo)) {
+      repos.push(repo);
+      localStorage.setItem(REPOS_KEY, JSON.stringify(repos));
+    }
+  } catch {
+    // ストレージ制限環境では無視
   }
 }
 
 export function removeRepo(repo: string): void {
-  const repos = getRepos().filter((r) => r !== repo);
-  localStorage.setItem(REPOS_KEY, JSON.stringify(repos));
+  try {
+    const repos = getRepos().filter((r) => r !== repo);
+    localStorage.setItem(REPOS_KEY, JSON.stringify(repos));
+  } catch {
+    // ストレージ制限環境では無視
+  }
 }

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -18,7 +18,10 @@ export function getRepos(): string[] {
   if (!raw) return [];
   try {
     const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as string[]) : [];
+    return Array.isArray(parsed) &&
+      parsed.every((item) => typeof item === "string")
+      ? parsed
+      : [];
   } catch {
     return [];
   }


### PR DESCRIPTION
## 概要

PAT・リポジトリリスト・APIキャッシュを localStorage に保存するユーティリティを実装。

## 変更内容

- **`src/lib/storage/settings.ts`**: 設定値の永続化
  - `getToken` / `setToken` / `removeToken`（キー: `giv:token`）
  - `getRepos` / `addRepo` / `removeRepo`（キー: `giv:repos`、重複追加防止）
  - localStorage が壊れている場合は空配列にフォールバック
- **`src/lib/storage/cache.ts`**: TTL 付きキャッシュ
  - `getCache` / `setCache` / `clearCache` / `clearAllCache`
  - デフォルト TTL: 5分（300,000ms）、カスタム TTL 指定可
  - キープレフィックス: `giv:cache:`（`clearAllCache` はキャッシュのみ削除）

## テスト結果

```
✓ src/lib/storage/settings.test.ts (11 tests)
✓ src/lib/storage/cache.test.ts    (10 tests)
✓ src/lib/github/client.test.ts    (12 tests)
Test Files  3 passed (3)
     Tests  33 passed (33)
```

Closes #3