### PR TITLE
[T4] 設定画面 UI 実装（PAT 入力・検証、リポジトリ管理）

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,15 +1,20 @@
+import { RepoManager } from "@/components/Settings/RepoManager";
+import { TokenForm } from "@/components/Settings/TokenForm";
 import Link from "next/link";
 
 export default function SettingsPage() {
   return (
-    <main className="max-w-4xl mx-auto px-4 py-8">
+    <main className="max-w-2xl mx-auto px-4 py-8">
       <div className="flex items-center gap-4 mb-6">
         <Link href="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← 戻る
+          ← メインリストへ戻る
         </Link>
         <h1 className="text-2xl font-bold">設定</h1>
       </div>
-      <p className="text-gray-500">設定画面（実装予定）</p>
+      <div className="flex flex-col gap-6">
+        <TokenForm />
+        <RepoManager />
+      </div>
     </main>
   );
 }

--- a/src/components/Settings/RepoManager.tsx
+++ b/src/components/Settings/RepoManager.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { getRepository } from "@/lib/github/client";
+import {
+  addRepo,
+  getRepos,
+  getToken,
+  removeRepo,
+} from "@/lib/storage/settings";
+import { useEffect, useState } from "react";
+
+export function RepoManager() {
+  const [input, setInput] = useState("");
+  const [repos, setRepos] = useState<string[]>([]);
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRepos(getRepos());
+  }, []);
+
+  async function handleAdd() {
+    const repo = input.trim();
+    if (!repo) return;
+
+    const [owner, name] = repo.split("/");
+    if (!owner || !name) {
+      setError("owner/repo の形式で入力してください");
+      return;
+    }
+
+    setAdding(true);
+    setError(null);
+    try {
+      const token = getToken() ?? undefined;
+      await getRepository(owner, name, token);
+      addRepo(repo);
+      setRepos(getRepos());
+      setInput("");
+    } catch {
+      setError(
+        "リポジトリが見つかりません、またはアクセス権限がありません（プライベートリポジトリにはトークンが必要です）",
+      );
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  function handleRemove(repo: string) {
+    removeRepo(repo);
+    setRepos(getRepos());
+  }
+
+  return (
+    <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold mb-4">リポジトリ</h2>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleAdd();
+          }}
+          placeholder="owner/repo"
+          className="flex-1 px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={!input.trim() || adding}
+          className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {adding ? "追加中..." : "追加"}
+        </button>
+      </div>
+      {error && <p className="mt-2 text-sm text-red-600">✗ {error}</p>}
+      {repos.length > 0 && (
+        <ul className="mt-4 divide-y divide-gray-100">
+          {repos.map((repo) => (
+            <li key={repo} className="flex items-center justify-between py-2">
+              <span className="text-sm font-mono">{repo}</span>
+              <button
+                type="button"
+                onClick={() => handleRemove(repo)}
+                className="text-sm text-red-600 hover:text-red-800"
+              >
+                削除
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {repos.length === 0 && (
+        <p className="mt-4 text-sm text-gray-400">
+          リポジトリが登録されていません
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/Settings/RepoManager.tsx
+++ b/src/components/Settings/RepoManager.tsx
@@ -54,7 +54,9 @@ export function RepoManager() {
 
   return (
     <section className="bg-white rounded-lg border border-gray-200 p-6">
-      <h2 className="text-lg font-semibold mb-4">リポジトリ</h2>
+      <h2 id="repo-section-label" className="text-lg font-semibold mb-4">
+        リポジトリ
+      </h2>
       <div className="flex gap-2">
         <input
           type="text"
@@ -67,6 +69,7 @@ export function RepoManager() {
             if (e.key === "Enter" && !adding) handleAdd();
           }}
           placeholder="owner/repo"
+          aria-label="リポジトリ名 (owner/repo 形式)"
           className="flex-1 px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <button
@@ -87,6 +90,7 @@ export function RepoManager() {
               <button
                 type="button"
                 onClick={() => handleRemove(repo)}
+                aria-label={`${repo} を削除`}
                 className="text-sm text-red-600 hover:text-red-800"
               >
                 削除

--- a/src/components/Settings/RepoManager.tsx
+++ b/src/components/Settings/RepoManager.tsx
@@ -24,7 +24,12 @@ export function RepoManager() {
     const repo = input.trim();
     if (!repo) return;
 
-    const [owner, name] = repo.split("/");
+    const parts = repo.split("/");
+    if (parts.length !== 2) {
+      setError("owner/repo の形式で入力してください");
+      return;
+    }
+    const [owner, name] = parts.map((p) => p.trim());
     if (!owner || !name) {
       setError("owner/repo の形式で入力してください");
       return;

--- a/src/components/Settings/RepoManager.tsx
+++ b/src/components/Settings/RepoManager.tsx
@@ -20,6 +20,7 @@ export function RepoManager() {
   }, []);
 
   async function handleAdd() {
+    if (adding) return;
     const repo = input.trim();
     if (!repo) return;
 
@@ -63,7 +64,7 @@ export function RepoManager() {
             setError(null);
           }}
           onKeyDown={(e) => {
-            if (e.key === "Enter") handleAdd();
+            if (e.key === "Enter" && !adding) handleAdd();
           }}
           placeholder="owner/repo"
           className="flex-1 px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/src/components/Settings/TokenForm.tsx
+++ b/src/components/Settings/TokenForm.tsx
@@ -58,6 +58,8 @@ export function TokenForm() {
             setValidation({ status: "idle" });
           }}
           placeholder="ghp_xxxxxxxxxxxx"
+          autoComplete="off"
+          spellCheck={false}
           className="flex-1 px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <button

--- a/src/components/Settings/TokenForm.tsx
+++ b/src/components/Settings/TokenForm.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { validateToken } from "@/lib/github/client";
+import { getToken, removeToken, setToken } from "@/lib/storage/settings";
+import { useEffect, useState } from "react";
+
+type ValidationState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; username: string }
+  | { status: "error"; message: string };
+
+export function TokenForm() {
+  const [input, setInput] = useState("");
+  const [saved, setSaved] = useState(false);
+  const [validation, setValidation] = useState<ValidationState>({
+    status: "idle",
+  });
+
+  useEffect(() => {
+    const token = getToken();
+    if (token) {
+      setInput(token);
+      setSaved(true);
+    }
+  }, []);
+
+  async function handleValidate() {
+    const token = input.trim();
+    if (!token) return;
+    setValidation({ status: "loading" });
+    try {
+      const user = await validateToken(token);
+      setToken(token);
+      setSaved(true);
+      setValidation({ status: "success", username: user.login });
+    } catch {
+      setValidation({ status: "error", message: "トークンが無効です" });
+    }
+  }
+
+  function handleRemove() {
+    removeToken();
+    setInput("");
+    setSaved(false);
+    setValidation({ status: "idle" });
+  }
+
+  return (
+    <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold mb-4">GitHub Token</h2>
+      <div className="flex gap-2">
+        <input
+          type="password"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            setSaved(false);
+            setValidation({ status: "idle" });
+          }}
+          placeholder="ghp_xxxxxxxxxxxx"
+          className="flex-1 px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button
+          type="button"
+          onClick={handleValidate}
+          disabled={!input.trim() || validation.status === "loading"}
+          className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {validation.status === "loading" ? "検証中..." : "検証"}
+        </button>
+        <button
+          type="button"
+          onClick={handleRemove}
+          disabled={!saved}
+          className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          削除
+        </button>
+      </div>
+      {validation.status === "success" && (
+        <p className="mt-2 text-sm text-green-600">
+          ✓ @{validation.username} として認証済み
+        </p>
+      )}
+      {validation.status === "error" && (
+        <p className="mt-2 text-sm text-red-600">✗ {validation.message}</p>
+      )}
+    </section>
+  );
+}

--- a/src/components/Settings/TokenForm.tsx
+++ b/src/components/Settings/TokenForm.tsx
@@ -48,7 +48,9 @@ export function TokenForm() {
 
   return (
     <section className="bg-white rounded-lg border border-gray-200 p-6">
-      <h2 className="text-lg font-semibold mb-4">GitHub Token</h2>
+      <h2 id="token-section-label" className="text-lg font-semibold mb-4">
+        GitHub Token
+      </h2>
       <div className="flex gap-2">
         <input
           type="password"
@@ -57,6 +59,7 @@ export function TokenForm() {
             setInput(e.target.value);
             setValidation({ status: "idle" });
           }}
+          aria-labelledby="token-section-label"
           placeholder="ghp_xxxxxxxxxxxx"
           autoComplete="off"
           spellCheck={false}

--- a/src/components/Settings/TokenForm.tsx
+++ b/src/components/Settings/TokenForm.tsx
@@ -12,7 +12,7 @@ type ValidationState =
 
 export function TokenForm() {
   const [input, setInput] = useState("");
-  const [saved, setSaved] = useState(false);
+  const [hasToken, setHasToken] = useState(false);
   const [validation, setValidation] = useState<ValidationState>({
     status: "idle",
   });
@@ -21,7 +21,7 @@ export function TokenForm() {
     const token = getToken();
     if (token) {
       setInput(token);
-      setSaved(true);
+      setHasToken(true);
     }
   }, []);
 
@@ -32,7 +32,7 @@ export function TokenForm() {
     try {
       const user = await validateToken(token);
       setToken(token);
-      setSaved(true);
+      setHasToken(true);
       setValidation({ status: "success", username: user.login });
     } catch {
       setValidation({ status: "error", message: "トークンが無効です" });
@@ -42,7 +42,7 @@ export function TokenForm() {
   function handleRemove() {
     removeToken();
     setInput("");
-    setSaved(false);
+    setHasToken(false);
     setValidation({ status: "idle" });
   }
 
@@ -55,7 +55,6 @@ export function TokenForm() {
           value={input}
           onChange={(e) => {
             setInput(e.target.value);
-            setSaved(false);
             setValidation({ status: "idle" });
           }}
           placeholder="ghp_xxxxxxxxxxxx"
@@ -72,7 +71,7 @@ export function TokenForm() {
         <button
           type="button"
           onClick={handleRemove}
-          disabled={!saved}
+          disabled={!hasToken}
           className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           削除

--- a/src/lib/github/client.test.ts
+++ b/src/lib/github/client.test.ts
@@ -160,6 +160,15 @@ describe("getRepository", () => {
     expect(error).toBeInstanceOf(GitHubApiError);
     expect(error.status).toBe(404);
   });
+
+  it("トークンなしの場合 Authorization ヘッダーを付与しない", async () => {
+    vi.mocked(fetch).mockReturnValueOnce(mockResponse(mockRepo) as never);
+    await getRepository("testuser", "test-repo");
+    const [, options] = vi.mocked(fetch).mock.calls[0];
+    const headers = (options as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers.Accept).toBe("application/vnd.github+json");
+  });
 });
 
 describe("getIssues", () => {

--- a/src/lib/github/client.ts
+++ b/src/lib/github/client.ts
@@ -17,15 +17,16 @@ export class GitHubApiError extends Error {
   }
 }
 
-function buildHeaders(token: string): HeadersInit {
-  return {
-    Authorization: `Bearer ${token}`,
+function buildHeaders(token?: string): HeadersInit {
+  const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
   };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
 }
 
-async function githubFetch(url: string, token: string): Promise<Response> {
+async function githubFetch(url: string, token?: string): Promise<Response> {
   const response = await fetch(url, { headers: buildHeaders(token) });
 
   if (!response.ok) {
@@ -48,7 +49,7 @@ function parseNextUrl(linkHeader: string | null): string | null {
   return match ? match[1] : null;
 }
 
-async function fetchAllPages<T>(url: string, token: string): Promise<T[]> {
+async function fetchAllPages<T>(url: string, token?: string): Promise<T[]> {
   const results: T[] = [];
   const initialUrl = new URL(url);
   initialUrl.searchParams.set("per_page", "100");
@@ -72,7 +73,7 @@ export async function validateToken(token: string): Promise<GitHubUser> {
 export async function getRepository(
   owner: string,
   repo: string,
-  token: string,
+  token?: string,
 ): Promise<GitHubRepository> {
   const response = await githubFetch(
     `${BASE_URL}/repos/${owner}/${repo}`,


### PR DESCRIPTION
## Summary

- `TokenForm.tsx`: PAT 入力（マスク表示）・検証（`GET /user`）・削除
- `RepoManager.tsx`: リポジトリ追加（`GET /repos/{owner}/{repo}` でアクセス確認）・一覧・削除。パブリックリポジトリはトークンなしで追加可能
- `settings/page.tsx`: 上記コンポーネントを組み込み
- `client.ts`: `getRepository` のトークンをオプション化

## Test plan

- [x] `npm run lint` パス
- [x] `npm test` パス（33 tests）
- [x] 動作確認（Issue #4 コメント参照）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)