### PR TITLE
[T5] Issue/PR データ取得・マージロジック実装

### DIFF
--- a/src/lib/github/client.ts
+++ b/src/lib/github/client.ts
@@ -85,7 +85,7 @@ export async function getRepository(
 export async function getIssues(
   owner: string,
   repo: string,
-  token: string,
+  token?: string,
 ): Promise<GitHubIssue[]> {
   return fetchAllPages<GitHubIssue>(
     `${BASE_URL}/repos/${owner}/${repo}/issues?state=all`,
@@ -96,7 +96,7 @@ export async function getIssues(
 export async function getPullRequests(
   owner: string,
   repo: string,
-  token: string,
+  token?: string,
 ): Promise<GitHubPullRequest[]> {
   return fetchAllPages<GitHubPullRequest>(
     `${BASE_URL}/repos/${owner}/${repo}/pulls?state=all`,

--- a/src/lib/github/parser.test.ts
+++ b/src/lib/github/parser.test.ts
@@ -53,4 +53,16 @@ describe("parseRelatedIssues", () => {
       parseRelatedIssues("This PR fixes #99 and also closes #100."),
     ).toEqual([99, 100]);
   });
+
+  it("prefixes #1 は抽出しない", () => {
+    expect(
+      parseRelatedIssues("This change prefixes #1 in generated text."),
+    ).toEqual([]);
+  });
+
+  it("unfixes #2 は抽出しない", () => {
+    expect(
+      parseRelatedIssues("This note mentions unfixes #2 as plain text."),
+    ).toEqual([]);
+  });
 });

--- a/src/lib/github/parser.test.ts
+++ b/src/lib/github/parser.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { parseRelatedIssues } from "./parser";
+
+describe("parseRelatedIssues", () => {
+  it("null は空配列を返す", () => {
+    expect(parseRelatedIssues(null)).toEqual([]);
+  });
+
+  it("空文字は空配列を返す", () => {
+    expect(parseRelatedIssues("")).toEqual([]);
+  });
+
+  it("キーワードがない本文は空配列を返す", () => {
+    expect(parseRelatedIssues("This PR adds a new feature.")).toEqual([]);
+  });
+
+  it("Closes #123 を抽出する", () => {
+    expect(parseRelatedIssues("Closes #123")).toEqual([123]);
+  });
+
+  it("Fixes #456 を抽出する", () => {
+    expect(parseRelatedIssues("Fixes #456")).toEqual([456]);
+  });
+
+  it("Resolves #789 を抽出する", () => {
+    expect(parseRelatedIssues("Resolves #789")).toEqual([789]);
+  });
+
+  it("Close（単数形）を抽出する", () => {
+    expect(parseRelatedIssues("Close #1")).toEqual([1]);
+  });
+
+  it("大文字小文字を区別しない", () => {
+    expect(parseRelatedIssues("closes #10\nFIXES #20")).toEqual([10, 20]);
+  });
+
+  it("owner/repo#123 形式を抽出する", () => {
+    expect(parseRelatedIssues("Closes owner/repo#42")).toEqual([42]);
+  });
+
+  it("複数の関連 Issue を抽出する", () => {
+    expect(parseRelatedIssues("Closes #1\nFixes #2\nResolves #3")).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("重複する Issue 番号は1件にまとめる", () => {
+    expect(parseRelatedIssues("Closes #5\nFixes #5")).toEqual([5]);
+  });
+
+  it("本文中に埋め込まれたキーワードも抽出する", () => {
+    expect(
+      parseRelatedIssues("This PR fixes #99 and also closes #100."),
+    ).toEqual([99, 100]);
+  });
+});

--- a/src/lib/github/parser.ts
+++ b/src/lib/github/parser.ts
@@ -1,6 +1,6 @@
 // Closes/Fixes/Resolves #123 または owner/repo#123 形式を抽出
 const RELATED_ISSUE_RE =
-  /(?:closes?|fixes?|resolves?)\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#(\d+)/gi;
+  /\b(?:closes?|fixes?|resolves?)\b\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#(\d+)/gi;
 
 export function parseRelatedIssues(body: string | null): number[] {
   if (!body) return [];

--- a/src/lib/github/parser.ts
+++ b/src/lib/github/parser.ts
@@ -1,0 +1,12 @@
+// Closes/Fixes/Resolves #123 または owner/repo#123 形式を抽出
+const RELATED_ISSUE_RE =
+  /(?:closes?|fixes?|resolves?)\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)?#(\d+)/gi;
+
+export function parseRelatedIssues(body: string | null): number[] {
+  if (!body) return [];
+  const numbers = new Set<number>();
+  for (const match of body.matchAll(RELATED_ISSUE_RE)) {
+    numbers.add(Number(match[1]));
+  }
+  return [...numbers];
+}

--- a/src/lib/hooks/useGitHubData.ts
+++ b/src/lib/hooks/useGitHubData.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { getIssues, getPullRequests } from "@/lib/github/client";
+import { getCache, setCache } from "@/lib/storage/cache";
+import { getRepos, getToken } from "@/lib/storage/settings";
+import type { GitHubItem } from "@/types";
+import { useCallback, useEffect, useState } from "react";
+
+type State =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; data: GitHubItem[]; fetchedAt: number }
+  | { status: "error"; message: string };
+
+async function fetchRepoItems(
+  repo: string,
+  token: string | null,
+): Promise<GitHubItem[]> {
+  const [owner, name] = repo.split("/");
+  const t = token ?? undefined;
+  const [issues, prs] = await Promise.all([
+    getIssues(owner, name, t),
+    getPullRequests(owner, name, t),
+  ]);
+
+  const issueItems: GitHubItem[] = issues
+    .filter((issue) => !issue.pull_request)
+    .map((issue) => ({ kind: "issue" as const, ...issue }));
+
+  const prItems: GitHubItem[] = prs.map((pr) => ({
+    kind: "pull_request" as const,
+    ...pr,
+  }));
+
+  return [...issueItems, ...prItems];
+}
+
+export function useGitHubData() {
+  const [state, setState] = useState<State>({ status: "idle" });
+
+  const load = useCallback(async (forceRefresh = false) => {
+    const repos = getRepos();
+    const token = getToken();
+
+    if (repos.length === 0) {
+      setState({ status: "success", data: [], fetchedAt: Date.now() });
+      return;
+    }
+
+    setState({ status: "loading" });
+
+    try {
+      const allItems: GitHubItem[] = [];
+
+      await Promise.all(
+        repos.map(async (repo) => {
+          const cacheKey = repo;
+
+          if (!forceRefresh) {
+            const cached = getCache<GitHubItem[]>(cacheKey);
+            if (cached) {
+              allItems.push(...cached);
+              return;
+            }
+          }
+
+          const items = await fetchRepoItems(repo, token);
+          setCache(cacheKey, items);
+          allItems.push(...items);
+        }),
+      );
+
+      const sorted = allItems.sort(
+        (a, b) =>
+          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+      );
+
+      setState({ status: "success", data: sorted, fetchedAt: Date.now() });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "データの取得に失敗しました";
+      setState({ status: "error", message });
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const refresh = useCallback(() => load(true), [load]);
+
+  return { state, refresh };
+}

--- a/src/lib/hooks/useGitHubData.ts
+++ b/src/lib/hooks/useGitHubData.ts
@@ -12,11 +12,22 @@ type State =
   | { status: "success"; data: GitHubItem[]; fetchedAt: number }
   | { status: "error"; message: string };
 
+function parseRepoIdentifier(repo: string): { owner: string; name: string } {
+  const parts = repo.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(
+      `リポジトリ設定 "${repo}" は不正です。"owner/repo" 形式で指定してください。`,
+    );
+  }
+  const [owner, name] = parts;
+  return { owner, name };
+}
+
 async function fetchRepoItems(
   repo: string,
   token: string | null,
 ): Promise<GitHubItem[]> {
-  const [owner, name] = repo.split("/");
+  const { owner, name } = parseRepoIdentifier(repo);
   const t = token ?? undefined;
   const [issues, prs] = await Promise.all([
     getIssues(owner, name, t),

--- a/src/lib/hooks/useSettings.ts
+++ b/src/lib/hooks/useSettings.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  addRepo,
+  getRepos,
+  getToken,
+  removeRepo,
+  removeToken,
+  setToken,
+} from "@/lib/storage/settings";
+import { useCallback, useEffect, useState } from "react";
+
+export function useSettings() {
+  const [token, setTokenState] = useState<string | null>(null);
+  const [repos, setReposState] = useState<string[]>([]);
+
+  useEffect(() => {
+    setTokenState(getToken());
+    setReposState(getRepos());
+  }, []);
+
+  const saveToken = useCallback((t: string) => {
+    setToken(t);
+    setTokenState(t);
+  }, []);
+
+  const deleteToken = useCallback(() => {
+    removeToken();
+    setTokenState(null);
+  }, []);
+
+  const addRepository = useCallback((repo: string) => {
+    addRepo(repo);
+    setReposState(getRepos());
+  }, []);
+
+  const removeRepository = useCallback((repo: string) => {
+    removeRepo(repo);
+    setReposState(getRepos());
+  }, []);
+
+  return {
+    token,
+    repos,
+    saveToken,
+    deleteToken,
+    addRepository,
+    removeRepository,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,11 @@
+import type { GitHubIssue, GitHubPullRequest } from "@/lib/github/types";
+
+export type GitHubItem =
+  | ({ kind: "issue" } & GitHubIssue)
+  | ({ kind: "pull_request" } & GitHubPullRequest);
+
+export type RepoData = {
+  repo: string;
+  items: GitHubItem[];
+  fetchedAt: number;
+};


### PR DESCRIPTION
## Summary

- `src/types/index.ts`: `GitHubItem` 統合型（issue / pull_request を `kind` で区別）
- `src/lib/github/parser.ts`: PR 本文から関連 Issue 番号を抽出（`Closes/Fixes/Resolves #XX`・`owner/repo#XX` 対応）
- `src/lib/github/parser.test.ts`: 12 件のユニットテスト
- `src/lib/hooks/useSettings.ts`: PAT・リポジトリリストの読み書きフック
- `src/lib/hooks/useGitHubData.ts`: 複数リポジトリの Issue+PR を並行取得・キャッシュ管理・更新日時降順マージ・手動リフレッシュ

## Test plan

- [x] `npm run lint` パス
- [x] `npm test` パス（46 tests）

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)