### PR TITLE
[T7] ユニットテスト整備

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@tailwindcss/postcss": "^4.1.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -24,6 +26,13 @@
         "typescript": "^5.8.3",
         "vitest": "^3.1.2"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -50,6 +59,51 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -2063,6 +2117,90 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2243,6 +2381,41 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2350,6 +2523,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -2420,6 +2600,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2429,6 +2619,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
@@ -2618,6 +2816,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2966,6 +3174,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2974,6 +3193,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -3176,6 +3405,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3205,6 +3450,28 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rollup": {
@@ -3395,6 +3662,19 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@tailwindcss/postcss": "^4.1.4",
-        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
@@ -26,13 +25,6 @@
         "typescript": "^5.8.3",
         "vitest": "^3.1.2"
       }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2138,33 +2130,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
@@ -2412,6 +2377,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2523,13 +2489,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -2606,6 +2565,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2816,16 +2776,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3195,16 +3145,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3460,20 +3400,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -3662,19 +3588,6 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@tailwindcss/postcss": "^4.1.4",
-    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@tailwindcss/postcss": "^4.1.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/src/lib/hooks/useGitHubData.test.ts
+++ b/src/lib/hooks/useGitHubData.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitHubIssue, GitHubPullRequest } from "../github/types";
+import type { GitHubUser } from "../github/types";
+import { useGitHubData } from "./useGitHubData";
+
+// --- fixtures ---
+
+const mockUser: GitHubUser = {
+  login: "testuser",
+  id: 1,
+  avatar_url: "https://avatars.githubusercontent.com/u/1",
+  html_url: "https://github.com/testuser",
+};
+
+const makeIssue = (n: number, updatedAt: string): GitHubIssue => ({
+  id: n,
+  number: n,
+  title: `Issue ${n}`,
+  state: "open",
+  body: null,
+  html_url: `https://github.com/owner/repo/issues/${n}`,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: updatedAt,
+  closed_at: null,
+  labels: [],
+  assignees: [],
+  milestone: null,
+  user: mockUser,
+});
+
+const makePR = (n: number, updatedAt: string): GitHubPullRequest => ({
+  id: n + 100,
+  number: n,
+  title: `PR ${n}`,
+  state: "open",
+  draft: false,
+  body: null,
+  html_url: `https://github.com/owner/repo/pull/${n}`,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: updatedAt,
+  closed_at: null,
+  merged_at: null,
+  labels: [],
+  assignees: [],
+  milestone: null,
+  user: mockUser,
+});
+
+function mockFetch(...pages: unknown[]) {
+  let call = 0;
+  vi.mocked(fetch).mockImplementation(() => {
+    const data = pages[call++] ?? [];
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.resolve(data),
+      headers: { get: () => null },
+    } as unknown as Response);
+  });
+}
+
+// --- tests ---
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useGitHubData — リポジトリ未設定", () => {
+  it("リポジトリが未設定の場合は success + data=[] + hasRepos=false", async () => {
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    const state = result.current.state;
+    if (state.status === "success") {
+      expect(state.data).toEqual([]);
+      expect(state.hasRepos).toBe(false);
+    }
+  });
+});
+
+describe("useGitHubData — データ取得", () => {
+  beforeEach(() => {
+    localStorage.setItem("giv:repos", JSON.stringify(["owner/repo"]));
+  });
+
+  it("Issue と PR を取得して success になる", async () => {
+    mockFetch(
+      [makeIssue(1, "2024-01-02T00:00:00Z")],
+      [makePR(2, "2024-01-01T00:00:00Z")],
+    );
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    const state = result.current.state;
+    if (state.status === "success") {
+      expect(state.hasRepos).toBe(true);
+      expect(state.data).toHaveLength(2);
+    }
+  });
+
+  it("PR フィールドを持つ Issue は除外される", async () => {
+    const issueWithPR = {
+      ...makeIssue(1, "2024-01-01T00:00:00Z"),
+      pull_request: { url: "", html_url: "" },
+    };
+    mockFetch([issueWithPR], []);
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    const state = result.current.state;
+    if (state.status === "success") {
+      expect(state.data).toHaveLength(0);
+    }
+  });
+
+  it("アイテムに repo フィールドが付与される", async () => {
+    mockFetch([makeIssue(1, "2024-01-01T00:00:00Z")], []);
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    const state = result.current.state;
+    if (state.status === "success") {
+      expect(state.data[0].repo).toBe("owner/repo");
+    }
+  });
+
+  it("updated_at の降順で並び替えられる", async () => {
+    const issue1 = makeIssue(1, "2024-01-01T00:00:00Z");
+    const issue2 = makeIssue(2, "2024-01-03T00:00:00Z");
+    const issue3 = makeIssue(3, "2024-01-02T00:00:00Z");
+    mockFetch([issue1, issue2, issue3], []);
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    const state = result.current.state;
+    if (state.status === "success") {
+      expect(state.data.map((i) => i.number)).toEqual([2, 3, 1]);
+    }
+  });
+
+  it("API エラー時は error 状態になる", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: () => Promise.resolve({ message: "Bad credentials" }),
+      headers: { get: () => null },
+    } as unknown as Response);
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("error"));
+    const state = result.current.state;
+    if (state.status === "error") {
+      expect(state.message).toBe("Bad credentials");
+    }
+  });
+
+  it("不正なリポジトリ形式はエラーになる", async () => {
+    localStorage.setItem("giv:repos", JSON.stringify(["invalid-repo"]));
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("error"));
+    const state = result.current.state;
+    if (state.status === "error") {
+      expect(state.message).toContain("invalid-repo");
+    }
+  });
+});
+
+describe("useGitHubData — キャッシュ", () => {
+  beforeEach(() => {
+    localStorage.setItem("giv:repos", JSON.stringify(["owner/repo"]));
+  });
+
+  it("キャッシュがある場合は fetch を呼ばない", async () => {
+    const cached = [
+      {
+        ...makeIssue(1, "2024-01-01T00:00:00Z"),
+        kind: "issue",
+        repo: "owner/repo",
+      },
+    ];
+    localStorage.setItem(
+      "giv:cache:owner/repo",
+      JSON.stringify({ data: cached, timestamp: Date.now() }),
+    );
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("refresh(true) でキャッシュを無視して再取得する", async () => {
+    const cached = [
+      {
+        ...makeIssue(1, "2024-01-01T00:00:00Z"),
+        kind: "issue",
+        repo: "owner/repo",
+      },
+    ];
+    localStorage.setItem(
+      "giv:cache:owner/repo",
+      JSON.stringify({ data: cached, timestamp: Date.now() }),
+    );
+    mockFetch([makeIssue(2, "2024-01-02T00:00:00Z")], []);
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    act(() => {
+      result.current.refresh();
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    expect(fetch).toHaveBeenCalled();
+  });
+});

--- a/src/lib/hooks/useGitHubData.test.ts
+++ b/src/lib/hooks/useGitHubData.test.ts
@@ -190,7 +190,7 @@ describe("useGitHubData — キャッシュ", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("refresh(true) でキャッシュを無視して再取得する", async () => {
+  it("refresh() でキャッシュを無視して再取得する", async () => {
     const cached = [
       {
         ...makeIssue(1, "2024-01-01T00:00:00Z"),

--- a/src/lib/hooks/useSettings.test.ts
+++ b/src/lib/hooks/useSettings.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSettings } from "./useSettings";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useSettings", () => {
+  it("初期状態は token=null・repos=[]", () => {
+    const { result } = renderHook(() => useSettings());
+    expect(result.current.token).toBeNull();
+    expect(result.current.repos).toEqual([]);
+  });
+
+  it("localStorage に token がある場合は初期値として読み込む", () => {
+    localStorage.setItem("giv:token", "existing-token");
+    const { result } = renderHook(() => useSettings());
+    expect(result.current.token).toBe("existing-token");
+  });
+
+  it("localStorage に repos がある場合は初期値として読み込む", () => {
+    localStorage.setItem("giv:repos", JSON.stringify(["owner/repo"]));
+    const { result } = renderHook(() => useSettings());
+    expect(result.current.repos).toEqual(["owner/repo"]);
+  });
+
+  it("saveToken でトークンを保存できる", () => {
+    const { result } = renderHook(() => useSettings());
+    act(() => {
+      result.current.saveToken("new-token");
+    });
+    expect(result.current.token).toBe("new-token");
+    expect(localStorage.getItem("giv:token")).toBe("new-token");
+  });
+
+  it("deleteToken でトークンを削除できる", () => {
+    localStorage.setItem("giv:token", "my-token");
+    const { result } = renderHook(() => useSettings());
+    act(() => {
+      result.current.deleteToken();
+    });
+    expect(result.current.token).toBeNull();
+    expect(localStorage.getItem("giv:token")).toBeNull();
+  });
+
+  it("addRepository でリポジトリを追加できる", () => {
+    const { result } = renderHook(() => useSettings());
+    act(() => {
+      result.current.addRepository("owner/repo");
+    });
+    expect(result.current.repos).toEqual(["owner/repo"]);
+    expect(localStorage.getItem("giv:repos")).toBe(
+      JSON.stringify(["owner/repo"]),
+    );
+  });
+
+  it("removeRepository でリポジトリを削除できる", () => {
+    localStorage.setItem(
+      "giv:repos",
+      JSON.stringify(["owner/repo1", "owner/repo2"]),
+    );
+    const { result } = renderHook(() => useSettings());
+    act(() => {
+      result.current.removeRepository("owner/repo1");
+    });
+    expect(result.current.repos).toEqual(["owner/repo2"]);
+  });
+});


### PR DESCRIPTION
## 概要

`lib/hooks/` 配下のフックに対するユニットテストを追加。既存4ファイルは要件通り揃っていることを確認済み。

## 変更内容

- `@testing-library/react` / `@testing-library/jest-dom` をインストール
- `src/lib/hooks/useSettings.test.ts` — 7テスト新規追加
- `src/lib/hooks/useGitHubData.test.ts` — 9テスト新規追加

## テスト結果

| ファイル | テスト数 |
|---------|---------|
| `client.test.ts` | 13 |
| `parser.test.ts` | 14 |
| `cache.test.ts` | 10 |
| `settings.test.ts` | 11 |
| `useSettings.test.ts` | 7（新規）|
| `useGitHubData.test.ts` | 9（新規）|
| **合計** | **64** |

## 関連 Issue

Closes #7

## Test plan

- [x] 全 64 テスト通過（`npm test`）
- [x] Biome lint クリア（`npm run lint`）
- [x] ビルド成功（`npm run build`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)