### PR TITLE
chore: develop → master 2026-05-21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-issue-viewer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-issue-viewer",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "next": "^16.2.6",
         "react": "^19.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@biomejs/biome": "^2.4.15",
         "@tailwindcss/postcss": "^4.3.0",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^25.7.0",
+        "@types/node": "^25.9.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "cross-env": "^10.1.0",
@@ -1899,13 +1899,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
@@ -3316,9 +3316,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@biomejs/biome": "^2.4.15",
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^25.7.0",
+    "@types/node": "^25.9.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "cross-env": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-issue-viewer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 概要

develop ブランチの変更を master にマージします。

## 含まれる変更

- 0c3a82d chore: bump version to 0.3.3 [skip ci]
- 5bf8e98 Merge pull request #29 from ot-nemoto/dependabot/npm_and_yarn/develop/development-dependencies-68ebe471cf
- 289a372 build(deps-dev): Bump @types/node in the development-dependencies group

🤖 このPRは自動生成されました