### PR TITLE
[T11] リポジトリ単位のエラーハンドリング改善

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "assist": {
     "enabled": true,
     "actions": {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -151,6 +151,18 @@ export default function HomePage() {
 
         {state.status === "success" && state.hasRepos && (
           <div className="space-y-3">
+            {state.failedRepos.length > 0 && (
+              <div className="rounded-md border border-[#f9c513] bg-[#fff8c5] px-4 py-3 text-sm text-[#7d4e00]">
+                <p className="font-semibold mb-1">一部のリポジトリの取得に失敗しました</p>
+                <ul className="list-disc list-inside space-y-0.5">
+                  {state.failedRepos.map(({ repo, message }) => (
+                    <li key={repo}>
+                      <span className="font-mono">{repo}</span>: {message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <FilterBar
               filter={filter}
               availableLabels={availableLabels}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -153,7 +153,9 @@ export default function HomePage() {
           <div className="space-y-3">
             {state.failedRepos.length > 0 && (
               <div className="rounded-md border border-[#f9c513] bg-[#fff8c5] px-4 py-3 text-sm text-[#7d4e00]">
-                <p className="font-semibold mb-1">一部のリポジトリの取得に失敗しました</p>
+                <p className="font-semibold mb-1">
+                  一部のリポジトリの取得に失敗しました
+                </p>
                 <ul className="list-disc list-inside space-y-0.5">
                   {state.failedRepos.map(({ repo, message }) => (
                     <li key={repo}>

--- a/src/lib/hooks/useGitHubData.test.ts
+++ b/src/lib/hooks/useGitHubData.test.ts
@@ -169,6 +169,35 @@ describe("useGitHubData — データ取得", () => {
       expect(state.message).toContain("invalid-repo");
     }
   });
+
+  it("1つのリポジトリが失敗しても他のデータは表示される", async () => {
+    // "invalid-repo" は parseRepoIdentifier で失敗、"owner/repo" は正常取得
+    localStorage.setItem(
+      "giv:repos",
+      JSON.stringify(["invalid-repo", "owner/repo"]),
+    );
+    mockFetch([makeIssue(1, "2024-01-01T00:00:00Z")], []);
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("success"));
+    const state = result.current.state;
+    if (state.status === "success") {
+      expect(state.data).toHaveLength(1);
+      expect(state.failedRepos).toHaveLength(1);
+      expect(state.failedRepos[0].repo).toBe("invalid-repo");
+    }
+  });
+
+  it("全リポジトリが失敗した場合は error 状態になる", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: () => Promise.resolve({ message: "Not Found" }),
+      headers: { get: () => null },
+    } as unknown as Response);
+    const { result } = renderHook(() => useGitHubData());
+    await waitFor(() => expect(result.current.state.status).toBe("error"));
+  });
 });
 
 describe("useGitHubData — キャッシュ", () => {

--- a/src/lib/hooks/useGitHubData.ts
+++ b/src/lib/hooks/useGitHubData.ts
@@ -6,6 +6,8 @@ import { getCache, setCache } from "@/lib/storage/cache";
 import { getRepos, getToken } from "@/lib/storage/settings";
 import type { GitHubItem } from "@/types";
 
+type FailedRepo = { repo: string; message: string };
+
 type State =
   | { status: "idle" }
   | { status: "loading" }
@@ -14,6 +16,7 @@ type State =
       data: GitHubItem[];
       fetchedAt: number;
       hasRepos: boolean;
+      failedRepos: FailedRepo[];
     }
   | { status: "error"; message: string };
 
@@ -65,49 +68,58 @@ export function useGitHubData() {
         data: [],
         fetchedAt: Date.now(),
         hasRepos: false,
+        failedRepos: [],
       });
       return;
     }
 
     setState({ status: "loading" });
 
-    try {
-      const allItems: GitHubItem[] = [];
+    const allItems: GitHubItem[] = [];
+    const failedRepos: FailedRepo[] = [];
 
-      await Promise.all(
-        repos.map(async (repo) => {
-          const cacheKey = repo;
+    await Promise.all(
+      repos.map(async (repo) => {
+        const cacheKey = repo;
 
-          if (!forceRefresh) {
-            const cached = getCache<GitHubItem[]>(cacheKey);
-            if (cached) {
-              allItems.push(...cached);
-              return;
-            }
+        if (!forceRefresh) {
+          const cached = getCache<GitHubItem[]>(cacheKey);
+          if (cached) {
+            allItems.push(...cached);
+            return;
           }
+        }
 
+        try {
           const items = await fetchRepoItems(repo, token);
           setCache(cacheKey, items);
           allItems.push(...items);
-        }),
-      );
+        } catch (err) {
+          const message =
+            err instanceof Error ? err.message : "データの取得に失敗しました";
+          failedRepos.push({ repo, message });
+        }
+      }),
+    );
 
-      const sorted = allItems.sort(
-        (a, b) =>
-          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
-      );
-
-      setState({
-        status: "success",
-        data: sorted,
-        fetchedAt: Date.now(),
-        hasRepos: true,
-      });
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "データの取得に失敗しました";
-      setState({ status: "error", message });
+    // 全リポジトリが失敗した場合のみ error 状態
+    if (failedRepos.length === repos.length) {
+      setState({ status: "error", message: failedRepos[0].message });
+      return;
     }
+
+    const sorted = allItems.sort(
+      (a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    );
+
+    setState({
+      status: "success",
+      data: sorted,
+      fetchedAt: Date.now(),
+      hasRepos: true,
+      failedRepos,
+    });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- 1つのリポジトリ取得が失敗しても、他のリポジトリのデータは表示し続けるよう改善
- 全リポジトリ失敗時のみ `error` 状態とし、部分失敗時は警告バナーを表示
- 部分失敗テストケースを追加

## Changes

- `src/lib/hooks/useGitHubData.ts` — `Promise.all` 内でリポジトリ単位に `try/catch` を追加。`failedRepos` を `success` 状態に含める
- `src/app/page.tsx` — `failedRepos` がある場合に黄色の警告バナーを表示
- `src/lib/hooks/useGitHubData.test.ts` — 部分失敗・全失敗のテストケースを追加

## Test plan

- [ ] 正常なリポジトリのみ設定 → 警告バナーなし、データ正常表示
- [ ] 存在しないリポジトリを1件＋正常なリポジトリを設定 → 正常データ表示＋警告バナー表示
- [ ] 全リポジトリ失敗 → error 状態（赤エラー＋再試行ボタン）
- [ ] CI pass（lint + unit test）

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)