### PR TITLE
[T15] CI実行タイミングの見直し（PR同期時の自動実行を停止し手動実行に変更）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, reopened]
     branches:
       - develop
       - master
+  workflow_dispatch:
 
 jobs:
   test:

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,11 +42,10 @@ npm run dev
 
 ### GitHub Pages
 
-`develop` ブランチへの push または `workflow_dispatch` で自動デプロイされる。
+`develop` ブランチへの push または `workflow_dispatch` で自動デプロイされる。`deploy-github-pages.yml` は `ci.yml` に依存しておらず、CI の成否とは無関係に実行される。
 
 ```
 develop ブランチへ push
-  → CI（lint + test）パス
   → build:static（./out 生成）
   → GitHub Pages デプロイ
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,6 +26,18 @@ npm run dev
 | `npm run lint` | Biome によるリント・フォーマットチェック |
 | `npm run test` | Vitest によるユニットテスト実行 |
 
+## CI
+
+`.github/workflows/ci.yml` は以下のタイミングで実行される。
+
+| トリガー | 実行 |
+|---------|------|
+| PR オープン（`opened` / `reopened`） | 自動実行 |
+| レビュー対応コミットのプッシュ（`synchronize`） | 自動実行しない |
+| 手動実行（`workflow_dispatch`） | いつでも実行可能 |
+
+`develop` / `master` に branch protection（必須ステータスチェック）は設定されていないため、CI 結果はマージのブロック要因にならない。**マージ前には GitHub Actions タブから手動でCIを再実行し、最終確認を行うこと。**
+
 ## デプロイ手順
 
 ### GitHub Pages


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` の `on.pull_request` に `types: [opened, reopened]` を追加し、レビュー対応コミットのプッシュ（synchronize）ではCIが自動実行されないようにした
- `workflow_dispatch` を追加し、任意のタイミングで手動実行できるようにした
- `docs/development.md` にCI運用ルール（マージ前の手動再実行）を追記

## Test plan
- [ ] このPRのオープンでCIが自動実行されること（Actionsタブで確認）
- [ ] このPRへの追加コミットでCIが自動実行されないこと
- [ ] Actionsタブから `workflow_dispatch` で手動実行できること

Closes #54