### PR TITLE
[T17] T15のCI実行タイミング変更を取り消し

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, reopened]
     branches:
       - develop
       - master

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,18 +26,6 @@ npm run dev
 | `npm run lint` | Biome によるリント・フォーマットチェック |
 | `npm run test` | Vitest によるユニットテスト実行 |
 
-## CI
-
-`.github/workflows/ci.yml` は以下のタイミングで実行される。
-
-| トリガー | 実行 |
-|---------|------|
-| PR オープン（`opened` / `reopened`） | 自動実行 |
-| レビュー対応コミットのプッシュ（`synchronize`） | 自動実行しない |
-| 手動実行（`workflow_dispatch`） | いつでも実行可能 |
-
-`develop` / `master` に branch protection（必須ステータスチェック）は設定されていないため、CI 結果はマージのブロック要因にならない。**マージ前には GitHub Actions タブから手動でCIを再実行し、最終確認を行うこと。**
-
 ## デプロイ手順
 
 ### GitHub Pages


### PR DESCRIPTION
## Summary
- 本リポジトリはpublicでGitHub-hosted runnerのActions実行時間は無料のため、[T15 (#54)](https://github.com/ot-nemoto/github-issue-viewer/issues/54) の「コスト回避のため synchronize では自動実行しない」という前提が成立しなかった
- `.github/workflows/ci.yml` を元に戻し、PRのあらゆるイベント（opened/synchronize/reopened）でCIが自動実行されるようにした（`workflow_dispatch` は手動実行の手段として残す）
- `docs/development.md` に追加していたCI運用ルール（手動再実行前提）のセクションを削除
- 同PRで入った、CIとは無関係のデプロイフロー図の誤り修正は取り消し対象に含めていない

## Test plan
- [ ] このPRのオープンでCIが自動実行されること
- [ ] このPRへの追加コミットでもCIが自動実行されること（T15以前の挙動に戻ったことの確認）
- [ ] Actionsタブから `workflow_dispatch` で手動実行できること

Closes #57